### PR TITLE
bump CPI Release to V20

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 * [Create an environment](https://bosh.io/docs/init.html)
     * [On Local machine (BOSH Lite)](https://bosh.io/docs/bosh-lite.html)
+    * [On Alibaba Cloud](https://bosh.io/docs/init-alicloud.html)
     * [On AWS](https://bosh.io/docs/init-aws.html)
     * [On Azure](https://bosh.io/docs/init-azure.html)
     * [On OpenStack](https://bosh.io/docs/init-openstack.html)
@@ -29,8 +30,8 @@
 ## Ops files
 
 - `bosh.yml`: Base manifest that is meant to be used with different CPI configurations
-- `[aws|azure|docker|gcp|openstack|softlayer|vcloud|vsphere|virtualbox]/cpi.yml`: CPI configuration
-- `[aws|azure|docker|gcp|openstack|softlayer|vcloud|vsphere|virtualbox]/cloud-config.yml`: Simple cloud configs
+- `[alicloud|aws|azure|docker|gcp|openstack|softlayer|vcloud|vsphere|virtualbox]/cpi.yml`: CPI configuration
+- `[alicloud|aws|azure|docker|gcp|openstack|softlayer|vcloud|vsphere|virtualbox]/cloud-config.yml`: Simple cloud configs
 - `jumpbox-user.yml`: Adds user `jumpbox` for SSH-ing into the Director (see [Jumpbox User](docs/jumpbox-user.md))
 - `uaa.yml`: Deploys UAA and enables UAA user management in the Director
 - `credhub.yml`: Deploys CredHub and enables CredHub integration in the Director

--- a/alicloud/cloud-config-vars.yml
+++ b/alicloud/cloud-config-vars.yml
@@ -1,0 +1,21 @@
+az1_zone:
+az1_vswitch_range:
+az1_vswitch_gateway:
+az1_vswitch_id:
+
+az2_zone:
+az2_vswitch_range:
+az2_vswitch_gateway:
+az2_vswitch_id:
+
+az3_zone:
+az3_vswitch_range:
+az3_vswitch_gateway:
+az3_vswitch_id:
+
+security_group_id_1:
+security_group_id_2:
+security_group_id_3:
+
+http_slb_id_array: []
+tcp_slb_id_array: []

--- a/alicloud/cloud-config.yml
+++ b/alicloud/cloud-config.yml
@@ -1,0 +1,106 @@
+azs:
+- name: z1
+  cloud_properties:
+    availability_zone: ((az1_zone))
+- name: z2
+  cloud_properties:
+    availability_zone: ((az2_zone))
+- name: z3
+  cloud_properties:
+    availability_zone: ((az3_zone))
+
+vm_types:
+- name: minimal
+  cloud_properties:
+    instance_type: ecs.mn4.small
+    ephemeral_disk: {size: "51_200"}
+- name: small
+  cloud_properties:
+    instance_type: ecs.sn2.medium
+    ephemeral_disk: {size: "51_200"}
+- name: default
+  cloud_properties:
+    instance_type: ecs.sn2.medium
+    ephemeral_disk: {size: "51_200"}
+- name: small-highmem
+  cloud_properties:
+    instance_type: ecs.sn2ne.xlarge
+    ephemeral_disk: {size: "51_200"}
+- name: compiler
+  cloud_properties:
+    instance_type: ecs.sn1.large
+    ephemeral_disk: {size: "51_200"}
+
+disk_types:
+- name: 5GB
+  disk_size: 20_480
+- name: 10GB
+  disk_size: 20_480
+- name: 100GB
+  disk_size: 102_400
+
+vm_extensions:
+- name: 5GB_ephemeral_disk
+  cloud_properties:
+    ephemeral_disk: {size: "20_480"}
+- name: 10GB_ephemeral_disk
+  cloud_properties:
+    ephemeral_disk: {size: "20_480"}
+- name: 50GB_ephemeral_disk
+  cloud_properties:
+    ephemeral_disk: {size: "50_120"}
+- name: 100GB_ephemeral_disk
+  cloud_properties:
+    ephemeral_disk: {size: "102_400"}
+- name: 500GB_ephemeral_disk
+  cloud_properties:
+    ephemeral_disk: {size: "512_000"}
+- name: 1TB_ephemeral_disk
+  cloud_properties:
+    ephemeral_disk: {size: "1024_000"}
+- name: cf-router-network-properties
+  cloud_properties:
+    slbs: ((http_slb_id_array))
+- name: cf-tcp-router-network-properties
+  cloud_properties:
+    slbs: ((tcp_slb_id_array))
+- name: diego-ssh-proxy-network-properties
+
+networks:
+- name: default
+  type: manual
+  subnets:
+  - range: ((az1_vswitch_range))
+    gateway: ((az1_vswitch_gateway))
+    az: z1
+    dns: [8.8.8.8]
+    cloud_properties:
+      vswitch_id: ((az1_vswitch_id))
+      security_group_ids:
+        - ((security_group_id_1))
+        - ((security_group_id_2))
+  - range: ((az2_vswitch_range))
+    gateway: ((az2_vswitch_gateway))
+    az: z2
+    dns: [8.8.8.8]
+    cloud_properties:
+      vswitch_id: ((az2_vswitch_id))
+      security_group_ids:
+        - ((security_group_id_1))
+        - ((security_group_id_2))
+  - range: ((az3_vswitch_range))
+    gateway: ((az3_vswitch_gateway))
+    az: z3
+    dns: [8.8.8.8]
+    cloud_properties:
+      vswitch_id: ((az3_vswitch_id))
+      security_group_ids: [((security_group_id_3))]
+- name: vip
+  type: vip
+
+compilation:
+  workers: 5
+  reuse_compilation_vms: true
+  az: z1
+  vm_type: compiler
+  network: default

--- a/alicloud/cpi.yml
+++ b/alicloud/cpi.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: bosh-alicloud-cpi
-    version: 18
-    url: http://bosh-((region)).oss-((region)).aliyuncs.com/bosh-alicloud-cpi-release-r18.tgz
-    sha1: 2e36b60f99e51fe2dd4e7ea021bf3ecce883487c
+    version: 19
+    url: https://github.com/cloudfoundry-incubator/bosh-alicloud-cpi-release/releases/download/V19/bosh-alicloud-cpi-release-r19.tgz
+    sha1: f58ee9bab45cb45036164cf170989751523fa6d8
 
 # light stemcell
 - type: replace
@@ -83,8 +83,8 @@
 - type: replace
   path: /instance_groups/name=bosh/properties/alicloud?
   value: &alicloud
-    region_id: ((region))
-    zone_id: ((zone))
+    region: ((region))
+    availability_zone: ((zone))
     access_key_id: ((access_key_id))
     access_key_secret: ((access_key_secret))
 

--- a/alicloud/cpi.yml
+++ b/alicloud/cpi.yml
@@ -12,8 +12,8 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell?
   value:
-    url: http://bosh-((region)).oss-((region)).aliyuncs.com/light-bosh-stemcell-1018-alicloud-kvm-ubuntu-trusty-go_agent.tgz
-    sha1: d8e8f51f5c90655ca4c76c7bada0b83f6e112533
+    url: http://bosh.oss-cn-hangzhou.aliyuncs.com/light-bosh-stemcell-1018-alicloud-kvm-ubuntu-xenial-go_agent.tgz
+    sha1: 7e004713a5eda2f3522631935ade0a08ec055936
 
 # Configure ECS sizes
 - type: replace

--- a/alicloud/cpi.yml
+++ b/alicloud/cpi.yml
@@ -1,0 +1,116 @@
+---
+# CPI
+- type: replace
+  path: /releases/-
+  value:
+    name: bosh-alicloud-cpi
+    version: 18
+    url: http://bosh-((region)).oss-((region)).aliyuncs.com/bosh-alicloud-cpi-release-r18.tgz
+    sha1: 2e36b60f99e51fe2dd4e7ea021bf3ecce883487c
+
+# light stemcell
+- type: replace
+  path: /resource_pools/name=vms/stemcell?
+  value:
+    url: http://bosh-((region)).oss-((region)).aliyuncs.com/light-bosh-stemcell-1018-alicloud-kvm-ubuntu-trusty-go_agent.tgz
+    sha1: d8e8f51f5c90655ca4c76c7bada0b83f6e112533
+
+# Configure ECS sizes
+- type: replace
+  path: /resource_pools/name=vms/cloud_properties?
+  value:
+    availability_zone: ((zone))
+    instance_type: "ecs.mn4.small"
+    instance_name: "bosh-director"
+    ephemeral_disk: {size: "51_200", category: "cloud_efficiency"}
+    system_disk: {size: "51_200", category: "cloud_efficiency"}
+    key_pair_name: ((key_pair_name))
+
+- type: replace
+  path: /disk_pools/name=disks/cloud_properties?
+  value:
+    type: "cloud_efficiency"
+    instance_role: "director"
+
+- type: replace
+  path: /networks/name=default/subnets/0/cloud_properties?
+  value:
+    vswitch_id: ((vswitch_id))
+    security_group_ids: [((security_group_id))]
+    internet_charge_type: "PayByTraffic"
+
+# Enable registry job
+- type: replace
+  path: /instance_groups/name=bosh/jobs/-
+  value:
+    name: registry
+    release: bosh
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/registry?
+  value:
+    address: ((internal_ip))
+    host: ((internal_ip))
+    db: # todo remove
+      host: 127.0.0.1
+      user: postgres
+      password: ((postgres_password))
+      database: bosh
+      adapter: postgres
+    http:
+      user: registry
+      password: ((registry_password))
+      port: 25777
+    username: registry
+    password: ((registry_password))
+    port: 25777
+
+# Add CPI job
+- type: replace
+  path: /instance_groups/name=bosh/jobs/-
+  value: &cpi_job
+    name: alicloud_cpi
+    release: bosh-alicloud-cpi
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/director/cpi_job?
+  value: alicloud_cpi
+
+- type: replace
+  path: /cloud_provider/template?
+  value: *cpi_job
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/alicloud?
+  value: &alicloud
+    region_id: ((region))
+    zone_id: ((zone))
+    access_key_id: ((access_key_id))
+    access_key_secret: ((access_key_secret))
+
+- type: replace
+  path: /cloud_provider/properties/alicloud?
+  value: *alicloud
+
+- type: replace
+  path: /cloud_provider/ssh_tunnel?
+  value:
+    host: ((internal_ip))
+    port: 22
+    user: vcap
+    private_key: ((private_key))
+
+- type: replace
+  path: /variables/-
+  value:
+    name: registry_password
+    type: password
+
+# Replace ntp to China timezone
+- type: replace
+  path: /instance_groups/name=bosh/properties/ntp?
+  value: &ntp
+  - server 0.cn.pool.ntp.org
+  - server 1.cn.pool.ntp.org
+  - server 2.cn.pool.ntp.org
+  - server 3.cn.pool.ntp.org

--- a/alicloud/cpi.yml
+++ b/alicloud/cpi.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: bosh-alicloud-cpi
-    version: 19
-    url: https://github.com/cloudfoundry-incubator/bosh-alicloud-cpi-release/releases/download/V19/bosh-alicloud-cpi-release-r19.tgz
-    sha1: f58ee9bab45cb45036164cf170989751523fa6d8
+    version: 20
+    url: https://github.com/cloudfoundry-incubator/bosh-alicloud-cpi-release/releases/download/V20/bosh-alicloud-cpi-release-r20.tgz
+    sha1: f9bc135fa481f3d30bf81b2928584e4f428f05ad
 
 # light stemcell
 - type: replace

--- a/alicloud/oss-blobstore.yml
+++ b/alicloud/oss-blobstore.yml
@@ -1,0 +1,20 @@
+---
+
+# Using Alibaba Cloud OSS Service as Bosh blobstore
+
+# Note: If you want to apply the current oss bucket for other blobstores,
+# you can specify 'bucket_name' to oss bucket and its one directory, like "((bucket_name))/bosh-blobs", and then the directory "bosh-blobs" will store all of bosh blobs.
+#
+# 'host' is oss bucket endpoint, and its format is 'oss-<regionId>.aliyuncs.com', like oss-cn-hangzhou.aliyuncs.com.
+
+- type: remove
+  path: /instance_groups/name=bosh/jobs/name=blobstore
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/blobstore?
+  value:
+    provider: s3
+    bucket_name: ((oss-bucket-name))
+    host: ((oss-host))
+    access_key_id: ((oss-access-key-id))
+    secret_access_key: ((oss-access-key-secret))

--- a/alicloud/releases-in-china.yml
+++ b/alicloud/releases-in-china.yml
@@ -1,0 +1,11 @@
+---
+
+# CPI
+- type: replace
+  path: /releases/name=bosh-alicloud-cpi/url?
+  value: http://bosh.oss-cn-hangzhou.aliyuncs.com/bosh-alicloud-cpi-release-r18.tgz
+
+# light stemcell
+- type: replace
+  path: /resource_pools/name=vms/stemcell/url?
+  value: http://bosh.oss-cn-hangzhou.aliyuncs.com/light-bosh-stemcell-1018-alicloud-kvm-ubuntu-trusty-go_agent.tgz

--- a/alicloud/releases-in-china.yml
+++ b/alicloud/releases-in-china.yml
@@ -4,8 +4,3 @@
 - type: replace
   path: /releases/name=bosh-alicloud-cpi/url?
   value: http://bosh.oss-cn-hangzhou.aliyuncs.com/bosh-alicloud-cpi-release-r19.tgz
-
-# light stemcell
-- type: replace
-  path: /resource_pools/name=vms/stemcell/url?
-  value: http://bosh.oss-cn-hangzhou.aliyuncs.com/light-bosh-stemcell-1018-alicloud-kvm-ubuntu-trusty-go_agent.tgz

--- a/alicloud/releases-in-china.yml
+++ b/alicloud/releases-in-china.yml
@@ -3,7 +3,7 @@
 # CPI
 - type: replace
   path: /releases/name=bosh-alicloud-cpi/url?
-  value: http://bosh.oss-cn-hangzhou.aliyuncs.com/bosh-alicloud-cpi-release-r18.tgz
+  value: http://bosh.oss-cn-hangzhou.aliyuncs.com/bosh-alicloud-cpi-release-r19.tgz
 
 # light stemcell
 - type: replace

--- a/alicloud/use-ubuntu-trusty.yml
+++ b/alicloud/use-ubuntu-trusty.yml
@@ -1,0 +1,25 @@
+# Trusty is going to go out of support in the near-ish future. We’ve switched the default well in advance of the support requirements of commercial CR distributions and cf-deployment’s role as the test manifest for CF.
+# This manifest is just used to support existing ubuntu trusty released. It is not recommend. Please use ubuntu xenial.
+
+- type: replace
+  path: /releases/name=bosh?
+  value:
+    name: bosh
+    version: "267.5.0"
+    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bosh-267.5.0-ubuntu-trusty-3586.26-20180822-001037-977484576-20180822001041.tgz?versionId=7.Is7sUkAU17rIy5lJ3cM6wvPJF7y1K9
+    sha1: 55711b9877a2c8af3739267e4381d63e8861999e
+
+- type: replace
+  path: /releases/name=bpm?
+  value:
+    name: bpm
+    version: "0.9.0"
+    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bpm-0.9.0-ubuntu-trusty-3586.26-20180725-183738-797989964-20180725183745.tgz?versionId=SZ82i5RS89h3BvuA68Gg2cYylTnwJIYI
+    sha1: 2ddb3e63a34a6eb201551d058120aec0767c267e
+
+# light ubuntu trusty stemcell
+- type: replace
+  path: /resource_pools/name=vms/stemcell?
+  value:
+    url: http://bosh.oss-cn-hangzhou.aliyuncs.com/light-bosh-stemcell-1018-alicloud-kvm-ubuntu-trusty-go_agent.tgz
+    sha1: d8e8f51f5c90655ca4c76c7bada0b83f6e112533


### PR DESCRIPTION
adjust ali.yml to use the latest version of bosh-alicloud-cpi-release.
https://github.com/cloudfoundry-incubator/bosh-alicloud-cpi-release